### PR TITLE
Suppress wallpaper popup and Imgur fixes

### DIFF
--- a/Tweak.m
+++ b/Tweak.m
@@ -105,8 +105,8 @@ __attribute__ ((constructor)) static void init(void) {
 			NSMutableURLRequest *mutableRequest = [request mutableCopy];
 
 			// Replace proxy urls with the real imgur api
-			NSString *newURLString = [request.URL.absoluteString stringByReplacingOccurrencesOfString:@"https://apollogur.download/api/" withString:@"https://api.imgur.com/3/"];
-			newURLString = [request.URL.absoluteString stringByReplacingOccurrencesOfString:@"https://imgur-apiv3.p.rapidapi.com/" withString:@"https://api.imgur.com/"];
+			NSString *newURLString = [requestURL stringByReplacingOccurrencesOfString:@"https://apollogur.download/api/" withString:@"https://api.imgur.com/3/"];
+			newURLString = [newURLString stringByReplacingOccurrencesOfString:@"https://imgur-apiv3.p.rapidapi.com/" withString:@"https://api.imgur.com/"];
 			mutableRequest.URL = [NSURL URLWithString:newURLString];
 
 			// Insert the api credential and update the request on this session task

--- a/Tweak.m
+++ b/Tweak.m
@@ -37,6 +37,9 @@ __attribute__ ((constructor)) static void init(void) {
 		{"SecItemUpdate", SecItemUpdate_replacement, (void *)&SecItemUpdate_orig}
 	}, 3);
 
+ 	// Suppress wallpaper popup
+	[[NSUserDefaults standardUserDefaults] setObject:[NSDate dateWithTimeIntervalSinceNow:60*60*24*90] forKey:@"WallpaperPromptMostRecent2"];
+ 
 	if (![[NSUserDefaults standardUserDefaults] valueForKey:@"ApolloRedditAPIClientID"]) {
 		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
 


### PR DESCRIPTION
The `WallpaperPromptMostRecent2` NSUserDefaults key stores the date of the last time the wallpaper prompt was shown.
Setting it to an arbitrary date in the future makes it so the start up check passes and the popup will never be shown.

I also made a partial fix to the "Imgur error :(" on certain Reddit posts. The `newURLString` was being overwritten with the original URL.

A complete fix with working uploads and deletes requires additional changes to handle Imgur API JSON endpoints and intercepting requests to `imgur-apiv3.p.rapidapi.com`.